### PR TITLE
 separate surfer and squid integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
 addons:
   ssh_known_hosts: shrimp.octet.services
 
-script: lein do clean, test :default
+script: lein do clean, test :default :integration
 
 branches:
   only:

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject sg.dex/starfish-clj "0.6.0"
   :url "https://github.com/DEX-Company/starfish-clj"
-  :dependencies [[sg.dex/starfish-java "0.7.0"]
+  :dependencies [ [sg.dex/starfish-java "0.7.0"]
                  [org.clojure/data.json "0.2.6"]
                  [clojurewerkz/propertied "1.3.0"]
                  [org.clojure/data.csv "0.1.4"]
@@ -12,7 +12,11 @@
   :java-source-paths ["src/main/java"]
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure" "src/test/java"]
-  :test-selectors {:default (complement :integration)
+  :test-selectors {:default (fn[m] 
+                             (not (or (clojure.string/includes? (str (:ns m))
+                                                              "integration")
+                                    (clojure.string/includes? (str (:name m))
+                                                              "integration")))) 
                    :integration :integration}
   :plugins [[lein-codox "0.10.7"]]
   :codox {:output-path "codox"}

--- a/src/test/clojure/integration/test_squid.clj
+++ b/src/test/clojure/integration/test_squid.clj
@@ -31,7 +31,7 @@
         sf (s/remote-agent did ddostring "Aladdin" "OpenSesame")]
     sf))
 
-(deftest ^:integration register-with-squid
+(deftest ^:squid-integration register-with-squid
   (testing "registration "
     (let [con-str "testdata"
           a1 (s/memory-asset {"random" "metadata"}

--- a/src/test/resources/squid_test.properties
+++ b/src/test/resources/squid_test.properties
@@ -1,8 +1,8 @@
 
 
 #Surfer Details
-surfer.host =http://52.187.164.74
-surfer.port=8080
+surfer.host =http://13.70.20.203
+surfer.port=8090
 surfer.username=Aladdin
 surfer.password=OpenSesame
 #Barge Details


### PR DESCRIPTION

* Add surfer integration tests back into travis
* add a new squid-integration test tag (which is excluded).
* change the tests to hit the latest Surfer instance. 